### PR TITLE
issue #17 GitHub Actionsでprod deployを自動化

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,94 @@
+name: Deploy Prod
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/deploy-prod.yml"
+      - "frontend/**"
+      - "backend/**"
+      - "infra/deploy/prod/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-prod:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: prod
+    env:
+      PROD_DEPLOY_PATH: ${{ vars.PROD_DEPLOY_PATH }}
+      PROD_SSH_HOST: ${{ vars.PROD_SSH_HOST }}
+      PROD_SSH_USER: ${{ vars.PROD_SSH_USER }}
+      RELEASE_ARCHIVE: kabi-chat-${{ github.sha }}.tar.gz
+      RELEASE_ENV_FILE: kabi-chat-${{ github.sha }}.env
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate prod compose build
+        run: DEPLOY_ENV_FILE=.env.example docker compose -f infra/deploy/prod/docker-compose.yml --env-file infra/deploy/prod/.env.example build gateway app
+
+      - name: Create release archive
+        run: git archive --format=tar.gz --output "$RELEASE_ARCHIVE" HEAD
+
+      - name: Write prod env file
+        run: |
+          cat <<'EOF' > "$RELEASE_ENV_FILE"
+          ${{ secrets.PROD_APP_ENV_FILE }}
+          EOF
+
+      - name: Configure SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          cat <<'EOF' > ~/.ssh/id_ed25519
+          ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          EOF
+          chmod 600 ~/.ssh/id_ed25519
+          cat <<'EOF' > ~/.ssh/known_hosts
+          ${{ secrets.PROD_SSH_KNOWN_HOSTS }}
+          EOF
+
+      - name: Upload release bundle
+        run: |
+          scp \
+            -i ~/.ssh/id_ed25519 \
+            -o StrictHostKeyChecking=yes \
+            "$RELEASE_ARCHIVE" \
+            "$RELEASE_ENV_FILE" \
+            "${PROD_SSH_USER}@${PROD_SSH_HOST}:/tmp/"
+
+      - name: Deploy on prod host
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes "${PROD_SSH_USER}@${PROD_SSH_HOST}" \
+            "DEPLOY_PATH='${PROD_DEPLOY_PATH}' RELEASE_SHA='${GITHUB_SHA}' RELEASE_ARCHIVE='/tmp/${RELEASE_ARCHIVE}' RELEASE_ENV_FILE='/tmp/${RELEASE_ENV_FILE}' bash -s" <<'EOF'
+          set -euo pipefail
+
+          deploy_path="${DEPLOY_PATH:-/opt/kabi-chat}"
+          release_dir="${deploy_path}/releases/${RELEASE_SHA}"
+          current_link="${deploy_path}/current"
+          shared_dir="${deploy_path}/shared"
+          shared_env_file="${shared_dir}/prod.env"
+
+          mkdir -p "${deploy_path}/releases" "${shared_dir}"
+          rm -rf "${release_dir}"
+          mkdir -p "${release_dir}"
+
+          tar -xzf "${RELEASE_ARCHIVE}" -C "${release_dir}"
+          install -m 600 "${RELEASE_ENV_FILE}" "${shared_env_file}"
+          ln -sfn "${release_dir}" "${current_link}"
+
+          cd "${current_link}"
+          cp "${shared_env_file}" infra/deploy/prod/.env
+          sh infra/deploy/prod/deploy.sh
+
+          rm -f "${RELEASE_ARCHIVE}" "${RELEASE_ENV_FILE}"
+          EOF

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Vite 開発サーバーは `http://localhost:5173` を既定とし、Backend API
 - Infrastructure は `infra/terraform/` 配下で `dev` / `prod` を分離します
 - アーリーアクセスの常設クラウド環境は低コストな単一 instance 構成を前提とします
 - 本番配備素材は `infra/deploy/prod/` に置き、reverse proxy + backend + PostgreSQL を同一 host に載せます
+- `main` merge から prod deploy までは GitHub Actions で自動化し、詳細は `docs/dev-workflow/prod-deploy.md` を参照します
 - 詳細な実装責務は `docs/architecture/*.md` を参照します
 
 ## Current Bootstrap Status

--- a/docs/architecture/infra.md
+++ b/docs/architecture/infra.md
@@ -49,6 +49,8 @@ ECS Fargate, RDS PostgreSQL, ALB, ECR は将来の拡張候補とし、アーリ
 - PostgreSQL は同一 host の private container network または localhost でのみ公開する
 - 外部公開は instance 上の reverse proxy を経由する
 - 公開 endpoint は HTTPS を前提とする
+- `main` への merge から prod deploy までは GitHub Actions を使って自動化する
+- GitHub Actions は release bundle を prod host に転送し、host 上の Docker Compose で `gateway`, `app`, `db` を更新する
 
 Docker Compose はローカル開発環境の再現用であり、クラウド環境とは compose file や secret の注入経路を分離します。アーリーアクセス中はローカル開発を主とし、クラウド `dev` は常設前提にしません。
 
@@ -79,6 +81,7 @@ MVP で最小限考慮する項目:
 - HTTPS 証明書の更新手段を持つ
 - DB の snapshot または dump backup 方針を持つ
 - instance 障害時に再作成できるよう Terraform と運用手順を分離する
+- GitHub Actions から prod host に到達する deploy credential と firewall 方針を定義する
 
 将来拡張:
 
@@ -87,4 +90,3 @@ MVP で最小限考慮する項目:
 - ALB や CDN の追加
 - CloudWatch ベースの監視
 - 監査ログ
-- CI/CD の自動化

--- a/docs/dev-workflow/prod-deploy.md
+++ b/docs/dev-workflow/prod-deploy.md
@@ -1,0 +1,103 @@
+# Production Deploy Workflow
+
+## Summary
+
+`main` への merge 後、GitHub Actions の `Deploy Prod` workflow が prod host へ release bundle を転送し、`infra/deploy/prod/deploy.sh` を実行して本番更新します。deploy 対象は Frontend / Backend / `infra/deploy/prod/` の変更です。
+
+本番 deploy は GitHub の `prod` environment を前提にし、credential は environment secrets / vars に寄せます。
+
+## Deploy Flow
+
+1. PR を `main` へ merge する
+2. `Deploy Prod` が起動し、`infra/deploy/prod/docker-compose.yml` の `gateway` と `app` build を検証する
+3. runner が `git archive` で release bundle を作成する
+4. runner が `PROD_APP_ENV_FILE` を一時ファイルへ展開する
+5. runner が SSH で prod host に release bundle と env file を転送する
+6. prod host が `/opt/kabi-chat/releases/<git-sha>` に展開し、`/opt/kabi-chat/current` を差し替える
+7. `infra/deploy/prod/deploy.sh` が `docker compose build app gateway` と `docker compose up -d --remove-orphans` を実行する
+
+`workflow_dispatch` も有効にしているため、同じ revision を手動で再 deploy できます。
+
+## GitHub Environment
+
+GitHub 上で `prod` environment を作成し、以下を設定します。
+
+### Secrets
+
+- `PROD_APP_ENV_FILE`
+  - `infra/deploy/prod/.env` の完成形をそのまま multi-line で保存する
+- `PROD_SSH_PRIVATE_KEY`
+  - prod host に入る deploy 用 private key
+- `PROD_SSH_KNOWN_HOSTS`
+  - `ssh-keyscan -H <prod-host>` の結果
+
+### Variables
+
+- `PROD_SSH_HOST`
+  - prod host の FQDN または IP
+- `PROD_SSH_USER`
+  - prod host に SSH する user
+- `PROD_DEPLOY_PATH`
+  - release を配置する base path
+  - 既定値は `/opt/kabi-chat`
+
+必要であれば GitHub Environment Protection Rules で required reviewers を付け、`main` merge 後も deploy 実行前に人手承認を挟みます。
+
+## Prod Host Preparation
+
+Lightsail instance 側では以下を事前に満たします。
+
+- Docker Engine と Docker Compose plugin を導入する
+- deploy user を作成し、`docker` group に所属させる
+- `mkdir -p /opt/kabi-chat/releases /opt/kabi-chat/shared` を実行できる権限を与える
+- `PROD_SSH_PRIVATE_KEY` に対応する public key を `~/.ssh/authorized_keys` に登録する
+- 初回だけ `PROD_SSH_KNOWN_HOSTS` 用に host key を採取する
+
+GitHub-hosted runner から直接 SSH する場合、送信元 IP を固定 CIDR で絞りにくい点に注意します。SSH の source 制限を厳格に維持したい場合は、self-hosted runner か固定 IP を持つ runner を使います。GitHub の larger runners では static IP を割り当てられます。
+
+## AWS Side Tasks
+
+- `infra/terraform/environments/prod/terraform.tfvars` を用意し、Lightsail instance / static IP / firewall を apply する
+- `APP_DOMAIN` の DNS を Lightsail static IP へ向ける
+- 80 / 443 を公開し、22 は deploy 方法に応じて制限する
+- 初回 deploy 前に Docker と Compose plugin を host に導入する
+- snapshot と backup の運用時刻を決める
+
+Terraform の `ssh_allowed_cidrs` を狭く保ちたい場合は、GitHub-hosted runner ではなく self-hosted runner への切り替えを検討します。
+
+## Discord Developer Portal Tasks
+
+- Production 用 redirect URI として `https://<APP_DOMAIN>/auth/discord/callback` を追加する
+- Frontend callback と整合する `AUTH_FRONTEND_CALLBACK_URL=https://<APP_DOMAIN>/login/callback` を `PROD_APP_ENV_FILE` に入れる
+- `APP_DOMAIN` を変更した場合は Discord 側 redirect URI も同時に更新する
+
+Discord 側の redirect URI は Backend の `DISCORD_REDIRECT_URI` と完全一致させます。
+
+## Updating Prod Env
+
+`PROD_APP_ENV_FILE` には少なくとも `infra/deploy/prod/.env.example` の項目を埋めます。
+
+- `APP_DOMAIN`
+- `ACME_EMAIL`
+- `POSTGRES_DB`
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `DATABASE_URL`
+- `DJANGO_SECRET_KEY`
+- `DJANGO_ALLOWED_HOSTS`
+- `DJANGO_CSRF_TRUSTED_ORIGINS`
+- `DISCORD_CLIENT_ID`
+- `DISCORD_CLIENT_SECRET`
+- `DISCORD_REDIRECT_URI`
+- `JWT_SIGNING_KEY`
+- `AUTH_FRONTEND_CALLBACK_URL`
+
+`VITE_API_BASE_URL` は same-origin 配信を使う場合は空文字のままで構いません。
+
+## Manual Recovery
+
+GitHub Actions を使わず手動で復旧したい場合は、prod host 上で最新の source を配置してから以下を実行します。
+
+```bash
+sh infra/deploy/prod/deploy.sh
+```

--- a/infra/deploy/prod/README.md
+++ b/infra/deploy/prod/README.md
@@ -6,6 +6,8 @@
 
 - `docker-compose.yml`
   - reverse proxy, backend, PostgreSQL を同一 host 上で起動する
+- `deploy.sh`
+  - prod compose の build / up をまとめて実行する
 - `Caddy.Dockerfile`
   - Frontend の build と Caddy image の組み立てをまとめる
 - `Caddyfile`
@@ -25,8 +27,7 @@
 
 ```bash
 cp infra/deploy/prod/.env.example infra/deploy/prod/.env
-docker compose -f infra/deploy/prod/docker-compose.yml --env-file infra/deploy/prod/.env build
-docker compose -f infra/deploy/prod/docker-compose.yml --env-file infra/deploy/prod/.env up -d
+sh infra/deploy/prod/deploy.sh
 ```
 
 `.env.example` で構文確認だけしたい場合は以下を使います。
@@ -41,3 +42,4 @@ DEPLOY_ENV_FILE=.env.example docker compose -f infra/deploy/prod/docker-compose.
 - TLS 証明書は Caddy が自動更新します
 - backup は `POSTGRES_USER` と `POSTGRES_DB` を export した上で `sh infra/deploy/prod/backup-postgres.sh` を実行します
 - `DJANGO_ALLOWED_HOSTS`, `DJANGO_CSRF_TRUSTED_ORIGINS`, `AUTH_FRONTEND_CALLBACK_URL`, `DISCORD_REDIRECT_URI` は同じ domain に揃えます
+- GitHub Actions からの自動 deploy は `docs/dev-workflow/prod-deploy.md` を参照します

--- a/infra/deploy/prod/deploy.sh
+++ b/infra/deploy/prod/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+project_root=$(CDPATH= cd -- "$script_dir/../../.." && pwd)
+compose_file="$script_dir/docker-compose.yml"
+env_file="${DEPLOY_ENV_FILE:-$script_dir/.env}"
+
+if [ ! -f "$env_file" ]; then
+  echo "deploy env file not found: $env_file" >&2
+  exit 1
+fi
+
+cd "$project_root"
+
+docker compose -f "$compose_file" --env-file "$env_file" build app gateway
+docker compose -f "$compose_file" --env-file "$env_file" up -d --remove-orphans


### PR DESCRIPTION
## 概要
- issue #17 に対応し、`main` への merge 後に prod host へ deploy する GitHub Actions を追加
- prod deploy 用の shell script と運用手順を追加
- GitHub / AWS / Discord Developer Portal 側で必要な前提設定を整理

## 変更内容
- `.github/workflows/deploy-prod.yml` を追加
- `infra/deploy/prod/deploy.sh` を追加
- `docs/dev-workflow/prod-deploy.md` を追加
- `README.md`、`docs/architecture/infra.md`、`infra/deploy/prod/README.md` を更新

## 動作確認
- `sh -n infra/deploy/prod/deploy.sh`
- `DEPLOY_ENV_FILE=.env.example docker compose -f infra/deploy/prod/docker-compose.yml --env-file infra/deploy/prod/.env.example config`
- `DEPLOY_ENV_FILE=.env.example docker compose -f infra/deploy/prod/docker-compose.yml --env-file infra/deploy/prod/.env.example build gateway app`

Closes #17