### PR TITLE
Fix Markdown renderer follow-ups

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,35 @@
+name: Frontend Build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/frontend-build.yml"
+      - "frontend/**"
+  push:
+    paths:
+      - ".github/workflows/frontend-build.yml"
+      - "frontend/**"
+
+jobs:
+  frontend-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build

--- a/frontend/src/shared/ui/MessageRenderer.jsx
+++ b/frontend/src/shared/ui/MessageRenderer.jsx
@@ -1,4 +1,4 @@
-import { Children, Suspense, isValidElement, lazy, memo, useMemo } from "react";
+import { Children, Component, Suspense, isValidElement, lazy, memo, useMemo } from "react";
 
 import katex from "katex";
 import ReactMarkdown from "react-markdown";
@@ -7,6 +7,19 @@ import remarkMath from "remark-math";
 
 const MARKDOWN_PLUGINS = [remarkGfm, remarkMath];
 const LazyMathJaxFallback = lazy(() => import("./MathJaxFallback"));
+
+function readTextContent(node) {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map((child) => readTextContent(child)).join("");
+  }
+  if (isValidElement(node)) {
+    return readTextContent(node.props.children);
+  }
+  return "";
+}
 
 function trimTrailingNewline(value) {
   return value.replace(/\n$/, "");
@@ -22,6 +35,29 @@ function renderKatex(value, displayMode) {
     });
   } catch {
     return "";
+  }
+}
+
+class MathRenderBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  static getDerivedStateFromError() {
+    return {
+      hasError: true,
+    };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <code className="markdown-math__source">{this.props.expression}</code>;
+    }
+
+    return this.props.children;
   }
 }
 
@@ -41,15 +77,17 @@ const MarkdownMath = memo(function MarkdownMath({ displayMode, value }) {
 
   return (
     <span className={displayMode ? "markdown-math markdown-math--display" : "markdown-math"}>
-      <Suspense fallback={<code className="markdown-math__source">{expression}</code>}>
-        <LazyMathJaxFallback displayMode={displayMode} expression={expression} />
-      </Suspense>
+      <MathRenderBoundary expression={expression}>
+        <Suspense fallback={<code className="markdown-math__source">{expression}</code>}>
+          <LazyMathJaxFallback displayMode={displayMode} expression={expression} />
+        </Suspense>
+      </MathRenderBoundary>
     </span>
   );
 });
 
 function MarkdownCode({ children, className, ...props }) {
-  const value = trimTrailingNewline(String(children));
+  const value = trimTrailingNewline(readTextContent(children));
   if (typeof className === "string" && className.includes("math-inline")) {
     return <MarkdownMath value={value} displayMode={false} />;
   }


### PR DESCRIPTION
## Summary
- fix math node text extraction so multiline inline TeX inside GFM tables renders correctly
- add an error boundary around lazy MathJax fallback so chunk-load failures degrade to source text instead of breaking the message subtree
- add a frontend GitHub Actions workflow that runs `npm ci` and `npm run build` on `frontend/**` changes

## Why
- addresses the review findings after #24
- fixes the reported broken matrix rendering in table cells
- ensures future frontend-only PRs get an actual CI signal

## Validation
- `cd frontend && npm run build`
- bundled server-side render check confirmed `| matrix | $\\begin{bmatrix}1 & 2\\\\3 & 4\\end{bmatrix}$ |` now produces a 2x2 KaTeX matrix

## Notes
- the bundle size warning remains and should be handled separately
- the MathJax dependency chain risk is not changed in this PR