### PR TITLE
[codex] Fix MathJax fallback rendering for matrix and unicode expressions

### DIFF
--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -40,7 +40,7 @@ Frontend の状態は以下に分離します。
 - TeX 描画は KaTeX を既定とする
 - raw モードではレンダリングせず入力文字列をそのまま表示する
 - view モードでは Markdown を HTML 化し、その中の数式を描画する
-- MathJax fallback は将来拡張として扱う
+- KaTeX で扱えない構文は限定的に MathJax fallback で補完する
 
 レンダリング負荷を抑えるため、message 再描画は必要最小限に限定する前提で設計します。
 

--- a/frontend/src/shared/ui/MathJaxFallback.jsx
+++ b/frontend/src/shared/ui/MathJaxFallback.jsx
@@ -2,9 +2,12 @@ import { MathJax, MathJaxContext } from "better-react-mathjax";
 
 const MATHJAX_CONFIG = {
   loader: {
-    load: ["input/tex", "output/chtml"],
+    load: ["input/tex", "output/chtml", "[tex]/ams", "[tex]/unicode"],
   },
   tex: {
+    packages: {
+      "[+]": ["ams", "unicode"],
+    },
     displayMath: [
       ["$$", "$$"],
       ["\\[", "\\]"],


### PR DESCRIPTION
## Summary
- enable the MathJax `ams` and `unicode` TeX extensions in the fallback renderer
- keep the frontend architecture doc aligned with the actual fallback behavior

## Why
KaTeX is the primary renderer, but unsupported expressions fall back to MathJax. The fallback config only loaded the base TeX input, so `\\begin{bmatrix}...\\end{bmatrix}` rendered as `Misplaced &` and `\\unicode{x03B1}` stayed unparsed.

## Impact
- matrix-style expressions now render correctly when they fall back to MathJax
- unicode control sequences handled by the MathJax extension now render correctly
- no API or data model changes

## Validation
- `npm run build` in `frontend/`
- local MathJax smoke check for `\\begin{bmatrix}1 & 2\\\\3 & 4\\end{bmatrix}` and `\\unicode{x03B1}`

## Links
- Closes #28