### PR TITLE
[codex] Fix matrix demo escaping in frontend sample data

### DIFF
--- a/frontend/src/shared/data/demo-data.js
+++ b/frontend/src/shared/data/demo-data.js
@@ -73,7 +73,7 @@ export const demoMessages = [
     id: 2002,
     channel_id: 201,
     body:
-      "KaTeX fallback check:\n\n- table support via GFM\n- MathJax fallback via `\\\\unicode`\n\n| item | preview |\n| --- | --- |\n| alpha | $\\\\unicode{x03B1}$ |\n| matrix | $\\\\begin{bmatrix}1 & 2\\\\\\\\3 & 4\\\\end{bmatrix}$ |",
+      "KaTeX fallback check:\n\n- table support via GFM\n- MathJax fallback via `\\unicode`\n\n| item | preview |\n| --- | --- |\n| alpha | $\\unicode{x03B1}$ |\n| matrix | $\\begin{bmatrix}1 & 2\\\\\\\\3 & 4\\end{bmatrix}$ |",
     author: {
       id: 3,
       username: "math-reviewer",


### PR DESCRIPTION
## Summary
Fix the remaining matrix rendering regression in the frontend demo message.

## What Changed
- corrected the TeX escape sequences in the Math Lab demo message fixture
- ensured the runtime message body contains `\unicode` and `\begin{bmatrix}...\end{bmatrix}` instead of doubly escaped control sequences

## Why
The previous matrix rendering fix updated the fallback renderer, but the demo message fixture still contained incorrectly escaped TeX source. That caused the rendered expression to hit `Misplaced &` for the matrix row separator.

## Impact
- affects the frontend demo/sample message shown in the Math Lab rendering channel
- no API or renderer logic changes

## Validation
- `npm run build` in `frontend/`
- verified the runtime string value from `demo-data.js` resolves to `\unicode` / `\begin` / `\end`

## Notes
- there is still no automated UI assertion for this specific demo rendering path