### PR TITLE
[codex] add autodev slash command prompt

### DIFF
--- a/.codex/prompts/autodev.md
+++ b/.codex/prompts/autodev.md
@@ -1,0 +1,20 @@
+---
+description: Run this repository's autodev workflow
+argument-hint: [REQUEST="<task or scope>"]
+---
+
+`[autodev]` モードとして依頼を処理してください。
+
+作業開始前に、必ず以下を確認してください。
+
+- `docs/agent-chat-rule/auto-develop.md`
+- `docs/dev-workflow/autodev.md`
+- 必要に応じて `docs/dev-workflow/code-review.md`
+
+要求解釈と制約は `docs/agent-chat-rule/auto-develop.md` を優先し、実行フローは `docs/dev-workflow/autodev.md` に従ってください。
+
+このスラッシュコマンドの後ろに続くテキストは、`[autodev]` を伴うユーザー要求として解釈してください。
+
+ユーザーからの追加指示:
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary
- replace the repo-root `.codex` placeholder file with a prompt directory
- add an `autodev` custom prompt definition at `.codex/prompts/autodev.md`
- align the prompt metadata and argument placeholder usage with the current Codex custom prompt format

## Why
The repository already documented `/autodev` as a valid trigger, but the actual prompt definition was missing, so the slash command was not available in Codex.

## Impact
- enables the repository-managed source definition for the `autodev` custom prompt
- no application runtime behavior changes
- no backend or frontend code changes

## Validation
- confirmed the prompt file exists in the repo at `.codex/prompts/autodev.md`
- confirmed the same prompt was installed to `~/.codex/prompts/autodev.md` for actual Codex loading
- verified the prompt structure against the current OpenAI Codex custom prompts documentation

## Known Issues / Next Steps
- Codex custom prompts are deprecated upstream in favor of skills, but the prompt path still supports the requested slash-command workflow
- prompt reload requires a new Codex session or restart